### PR TITLE
allow emitting floats

### DIFF
--- a/src/jvm/clj_json/JsonExt.java
+++ b/src/jvm/clj_json/JsonExt.java
@@ -76,6 +76,9 @@ public class JsonExt {
     } else if (obj instanceof Double) {
       jg.writeNumber((Double) obj);
     
+    } else if (obj instanceof Float) {
+      jg.writeNumber((Float) obj);
+    
     } else if (obj instanceof Boolean) {
       jg.writeBoolean((Boolean) obj);
     

--- a/test/clj_json/core_test.clj
+++ b/test/clj_json/core_test.clj
@@ -9,6 +9,9 @@
              "vec" [1 2 3] "map" {"a" "b"} "list" (list "a" "b")}]
     (is (= obj (json/parse-string (json/generate-string obj))))))
 
+(deftest test-generate-accepts-float
+  (is (= "3.14" (json/generate-string (float 3.14)))))
+  
 (deftest test-key-coercion
   (is (= {"foo" "bar" "1" "bat" "2" "bang" "3" "biz"}
          (json/parse-string


### PR DESCRIPTION
The generate-string function fails when given a float value;

  (json/generate-string (float 6.0))

This fix allows emitting floats.
