### PR TITLE
Add smile support to clj-json

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,19 @@ Fast JSON encoding and decoding for Clojure via the Jackson library.
     (json/parsed-seq
       (BufferedReader. (StringReader. "{\"foo\":\"bar\"}{\"biz\":\"bat\"}")))
     ({"foo" "bar"} {"biz" "bat"})
+
+## SMILE support
+
+    (require '(clj-json [core :as json]))
+
+    (json/generate-smile {:a 1 :b 2})
+    #<byte[] [B@5e9de959>
+
+    (json/parse-smile (json/generate-smile {:a 1 :b 2}))
+    {"a" 1, "b" 2}
+
+    (json/parsed-smile-seq (ByteArrayInputStream. <etc>))
+    {"a" 1, "b" 2}
     
 
 ## Installation

--- a/project.clj
+++ b/project.clj
@@ -1,13 +1,13 @@
-(defproject clj-json "0.3.1"
-  :description "Fast JSON encoding and decoding for Clojure via the Jackson library."
-  :url "http://github.com/mmcgrana/clj-json"
+(defproject org.clojars.thnetos/clj-json "0.3.2-SNAPSHOT"
+  :description "Fast JSON encoding and decoding for Clojure via the Jackson library. Forked to add SMILE support"
+  :url "http://github.com/dakrone/clj-json"
   :source-path "src/clj"
   :java-source-path "src/jvm"
   :javac-fork "true"
   :dependencies
     [[org.clojure/clojure "1.2.0"]
      [org.clojure/clojure-contrib "1.2.0"]
-     [org.codehaus.jackson/jackson-core-asl "1.6.2"]
-     [org.codehaus.jackson/jackson-smile "1.6.2"]]
+     [org.codehaus.jackson/jackson-core-asl "1.6.3"]
+     [org.codehaus.jackson/jackson-smile "1.6.3"]]
   :dev-dependencies
     [[org.clojars.mmcgrana/lein-javac "1.2.1"]])

--- a/project.clj
+++ b/project.clj
@@ -7,6 +7,7 @@
   :dependencies
     [[org.clojure/clojure "1.2.0"]
      [org.clojure/clojure-contrib "1.2.0"]
-     [org.codehaus.jackson/jackson-core-asl "1.5.0"]]
+     [org.codehaus.jackson/jackson-core-asl "1.6.2"]
+     [org.codehaus.jackson/jackson-smile "1.6.2"]]
   :dev-dependencies
     [[org.clojars.mmcgrana/lein-javac "1.2.1"]])

--- a/src/clj/clj_json/core.clj
+++ b/src/clj/clj_json/core.clj
@@ -1,12 +1,18 @@
 (ns clj-json.core
   (:import (clj_json JsonExt)
+           (org.codehaus.jackson.smile SmileFactory)
            (org.codehaus.jackson JsonFactory JsonParser JsonParser$Feature)
-           (java.io StringWriter StringReader BufferedReader))
+           (java.io StringWriter StringReader BufferedReader
+                    ByteArrayOutputStream))
   (:use (clojure.contrib [def :only (defvar-)])))
 
 (defvar- #^JsonFactory factory
   (doto (JsonFactory.)
     (.configure JsonParser$Feature/ALLOW_UNQUOTED_CONTROL_CHARS true)))
+
+;; Left blank here in case future options are needed
+(defvar- #^SmileFactory smile-factory
+  (SmileFactory.))
 
 (defn generate-string
   {:tag String
@@ -18,12 +24,28 @@
     (.flush generator)
     (.toString sw)))
 
+(defn generate-smile
+  "Returns a SMILE-encoded byte-array for the given Clojure object."
+  [obj]
+  (let [baos (ByteArrayOutputStream.)
+        generator (.createJsonGenerator smile-factory baos)]
+    (JsonExt/generate generator obj)
+    (.flush generator)
+    (.toByteArray baos)))
+
 (defn parse-string
   "Returns the Clojure object corresponding to the given JSON-encoded string."
   [string & [keywords]]
   (JsonExt/parse
     (.createJsonParser factory (StringReader. string))
     true (or keywords false) nil))
+
+(defn parse-smile
+  "Returns the Clojure object corresponding to the given SMILE-encoded bytes."
+  [bytes & [keywords]]
+  (JsonExt/parse
+   (.createJsonParser smile-factory bytes)
+   true (or keywords false) nil))
 
 (defn- parsed-seq* [#^JsonParser parser keywords]
   (let [eof (Object.)]
@@ -36,3 +58,8 @@
   "Returns a lazy seq of Clojure objects corresponding to the JSON read from
   the given reader. The seq continues until the end of the reader is reached."
   (parsed-seq* (.createJsonParser factory reader) (or keywords false)))
+
+(defn parsed-smile-seq [#^BufferedReader reader & [keywords]]
+  "Returns a lazy seq of Clojure objects corresponding to the SMILE read from
+  the given reader. The seq continues until the end of the reader is reached."
+  (parsed-seq* (.createJsonParser smile-factory reader) (or keywords false)))

--- a/test/clj_json/core_test.clj
+++ b/test/clj_json/core_test.clj
@@ -27,3 +27,9 @@
 (deftest test-parsed-seq
   (let [br (BufferedReader. (StringReader. "1\n2\n3\n"))]
     (is (= (list 1 2 3) (json/parsed-seq br)))))
+
+(deftest test-smile-round-trip
+  (let [obj {"int" 3 "long" 52001110638799097 "bigint" 9223372036854775808
+             "double" 1.23 "boolean" true "nil" nil "string" "string"
+             "vec" [1 2 3] "map" {"a" "b"} "list" (list "a" "b")}]
+    (is (= obj (json/parse-smile (json/generate-smile obj))))))


### PR DESCRIPTION
Hi mmcgrana,
I forked clj-json to add SMILE support, since it was added to Jackson in 1.6.0.

Feel free to discard the project.clj description/url/name changes, we needed a version of clj-json to use at work that was on clojars, so I pushed a SNAPSHOT version for our leiningen projects.
