### PR TITLE
Updates to remove clojure-contrib dependency and use new type-hint style

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -6,7 +6,6 @@
   :javac-fork "true"
   :dependencies
     [[org.clojure/clojure "1.2.0"]
-     [org.clojure/clojure-contrib "1.2.0"]
      [org.codehaus.jackson/jackson-core-asl "1.5.0"]]
   :dev-dependencies
     [[org.clojars.mmcgrana/lein-javac "1.2.1"]])

--- a/src/clj/clj_json/core.clj
+++ b/src/clj/clj_json/core.clj
@@ -1,10 +1,9 @@
 (ns clj-json.core
   (:import (clj_json JsonExt)
            (org.codehaus.jackson JsonFactory JsonParser JsonParser$Feature)
-           (java.io StringWriter StringReader BufferedReader))
-  (:use (clojure.contrib [def :only (defvar-)])))
+           (java.io StringWriter StringReader BufferedReader)))
 
-(defvar- #^JsonFactory factory
+(def ^{:tag JsonFactory, :private true} factory
   (doto (JsonFactory.)
     (.configure JsonParser$Feature/ALLOW_UNQUOTED_CONTROL_CHARS true)))
 

--- a/src/clj/clj_json/core.clj
+++ b/src/clj/clj_json/core.clj
@@ -8,8 +8,8 @@
     (.configure JsonParser$Feature/ALLOW_UNQUOTED_CONTROL_CHARS true)))
 
 (defn generate-string
-  {:tag String
-   :doc "Returns a JSON-encoding String for the given Clojure object."}
+  "Returns a JSON-encoding String for the given Clojure object."
+  {:tag String}
   [obj]
   (let [sw        (StringWriter.)
         generator (.createJsonGenerator factory sw)]
@@ -24,14 +24,14 @@
     (.createJsonParser factory (StringReader. string))
     true (or keywords false) nil))
 
-(defn- parsed-seq* [#^JsonParser parser keywords]
+(defn- parsed-seq* [^JsonParser parser keywords]
   (let [eof (Object.)]
     (lazy-seq
       (let [elem (JsonExt/parse parser true keywords eof)]
         (if-not (identical? elem eof)
           (cons elem (parsed-seq* parser keywords)))))))
 
-(defn parsed-seq [#^BufferedReader reader & [keywords]]
+(defn parsed-seq [^BufferedReader reader & [keywords]]
   "Returns a lazy seq of Clojure objects corresponding to the JSON read from
   the given reader. The seq continues until the end of the reader is reached."
   (parsed-seq* (.createJsonParser factory reader) (or keywords false)))


### PR DESCRIPTION
This change removes clojure-contrib as a dependency, and uses the "^Blah" type-hint style instead of the deprecated "#^Blah" style.
