### PR TITLE
NullPointerException in generate-string when *coercions* is non-nil

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject clj-json "0.4.2"
+(defproject clj-json "0.4.2-SNAPSHOT"
   :description "Fast JSON encoding and decoding for Clojure via the Jackson library."
   :url "http://github.com/mmcgrana/clj-json"
   :source-path "src/clj"

--- a/src/jvm/clj_json/JsonExt.java
+++ b/src/jvm/clj_json/JsonExt.java
@@ -30,7 +30,7 @@ public class JsonExt {
         }
 
         public void generate(Object obj) throws Exception{
-            if (this.coercions != null) {
+            if (this.coercions != null && obj != null) {
                 IFn fn;
                 while ((fn = (IFn)coercions.get(obj.getClass())) != null){
                     obj = fn.invoke(obj);

--- a/test/clj_json/core_test.clj
+++ b/test/clj_json/core_test.clj
@@ -40,3 +40,10 @@
     (is (= {"foo" {"bang" true, "bar" true}}
            (json/parse-string
             (json/generate-string {"foo" #{"bar" "bang"}}))))))
+
+(deftest test-redefine-coercions-with-nil
+  (binding [clj-json.core/*coercions* {clojure.lang.PersistentHashSet
+                                       (fn [x] (reduce (fn [acc x] (assoc acc x true)) {} x))}]
+    (is (= nil 
+           (json/parse-string
+            (json/generate-string nil))))))


### PR DESCRIPTION
Hi Mark,

Trying to generate object graphs that contain nil elements causes generate-string to crash with a NullPointerException instead of generating the appropriate JSON "null" elements. I think I've identified the problem and pushed a fix and a test. I'm new to github, so please let me know if a pull request seems like overkill for sending this minor patch.

By the way, thank you for the great work on clojure and ring!

Best regards,

Oliver
