### PR TITLE
Support java.util.Map instead of IPersistentMap

### DIFF
--- a/src/jvm/clj_json/JsonExt.java
+++ b/src/jvm/clj_json/JsonExt.java
@@ -9,17 +9,11 @@ import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Set;
 import clojure.lang.IFn;
-import clojure.lang.ISeq;
-import clojure.lang.IPersistentMap;
-import clojure.lang.IPersistentVector;
-import clojure.lang.IMapEntry;
 import clojure.lang.Keyword;
 import clojure.lang.PersistentArrayMap;
 import clojure.lang.PersistentVector;
 import clojure.lang.ITransientMap;
-import clojure.lang.IPersistentList;
 import clojure.lang.ITransientCollection;
-import clojure.lang.Seqable;
 
 public class JsonExt {
     public static class Generator {

--- a/src/jvm/clj_json/JsonExt.java
+++ b/src/jvm/clj_json/JsonExt.java
@@ -4,7 +4,9 @@ import org.codehaus.jackson.JsonToken;
 import org.codehaus.jackson.JsonParser;
 import org.codehaus.jackson.JsonGenerator;
 import java.math.BigInteger;
+import java.util.Iterator;
 import java.util.Map;
+import java.util.Map.Entry;
 import java.util.Set;
 import clojure.lang.IFn;
 import clojure.lang.ISeq;
@@ -64,13 +66,13 @@ public class JsonExt {
                 jg.writeNull();
             } else if (obj instanceof Keyword) {
                 jg.writeString(((Keyword) obj).getName());
-            } else if (obj instanceof IPersistentMap) {
-                IPersistentMap map = (IPersistentMap) obj;
-                ISeq mSeq = map.seq();
+            } else if (obj instanceof Map) {
+                Map map = (Map) obj;
+                Iterator iter = map.entrySet().iterator();
                 jg.writeStartObject();
-                while (mSeq != null) {
-                    IMapEntry me = (IMapEntry) mSeq.first();
-                    Object key = me.key();
+                while (iter.hasNext()) {
+                    Entry me = (Entry) iter.next();
+                    Object key = me.getKey();
                     if (key instanceof Keyword) {
                         jg.writeFieldName(((Keyword) key).getName());
                     } else if (key instanceof Integer) {
@@ -82,8 +84,7 @@ public class JsonExt {
                     } else {
                         jg.writeFieldName((String) key);
                     }
-                    generate(me.val());
-                    mSeq = mSeq.next();
+                    generate(me.getValue());
                 }
                 jg.writeEndObject();
             } else if (obj instanceof Iterable) {

--- a/test/clj_json/core_test.clj
+++ b/test/clj_json/core_test.clj
@@ -1,12 +1,14 @@
 (ns clj-json.core-test
   (:use clojure.test)
   (:require [clj-json.core :as json])
-  (:import (java.io StringReader BufferedReader)))
+  (:import (java.io StringReader BufferedReader)
+           (java.util HashMap)))
 
 (deftest test-string-round-trip
   (let [obj {"int" 3 "long" 52001110638799097 "bigint" 9223372036854775808
              "double" 1.23 "boolean" true "nil" nil "string" "string"
-             "vec" [1 2 3] "map" {"a" "b"} "list" (list "a" "b")}]
+             "vec" [1 2 3] "map" {"a" "b"} "list" (list "a" "b")
+             "hmap" (HashMap. {"a" "b"})}]
     (is (= obj (json/parse-string (json/generate-string obj))))))
 
 (deftest test-generate-accepts-float


### PR DESCRIPTION
I think java.util.Map is preferable for checking type, because all of clojure persistent map implement java.util.Map interface.
