### PR TITLE
BigDecimal support

### DIFF
--- a/src/jvm/clj_json/JsonExt.java
+++ b/src/jvm/clj_json/JsonExt.java
@@ -8,6 +8,7 @@ import java.util.Iterator;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Set;
+import java.math.BigDecimal;
 import clojure.lang.IFn;
 import clojure.lang.Keyword;
 import clojure.lang.PersistentArrayMap;
@@ -57,6 +58,10 @@ public class JsonExt {
                     jg.writeNumber((Double) obj);
                 } else if (obj instanceof Float) {
                     jg.writeNumber((Float) obj);
+                } else if (obj instanceof BigDecimal) {
+                    jg.writeNumber((BigDecimal) obj);
+                } else {
+                    throw new Exception("Cannot generate number "+obj);
                 }
             } else if (obj instanceof Boolean) {
                 jg.writeBoolean((Boolean) obj);

--- a/test/clj_json/core_test.clj
+++ b/test/clj_json/core_test.clj
@@ -61,3 +61,10 @@
       (is (= {"foo" {"bar" "empty"}}
              (json/parse-string
               (json/generate-string {"foo" {"bar" nil}})))))))
+
+
+(deftest test-bigdecimal
+  (is (= "{\"data1\":1,\"data2\":1.11}"
+          (json/generate-string {:data1 1M :data2 1.11M})))
+)
+


### PR DESCRIPTION
clj-json throws an exception 
"org.codehaus.jackson.JsonGenerationException: Can not write a field name, expecting a value"
when serializing map containing BigDecimal values, something like {:total 10.0M}

I have added BigDecimal support and exception for unknown number types in "generate" method and test-bigdecimal to unit tests.
