### PR TITLE
Feature/generate to writer

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject clj-json "0.5.0"
+(defproject clj-json "0.5.1"
   :description "Fast JSON encoding and decoding for Clojure via the Jackson library."
   :url "http://github.com/mmcgrana/clj-json"
   :source-path "src/clj"

--- a/src/clj/clj_json/core.clj
+++ b/src/clj/clj_json/core.clj
@@ -1,7 +1,7 @@
 (ns clj-json.core
   (:import (clj_json JsonExt)
            (org.codehaus.jackson JsonFactory JsonParser JsonParser$Feature)
-           (java.io StringWriter StringReader BufferedReader))
+           (java.io Writer StringWriter StringReader BufferedReader))
   (:use (clojure [walk :only (postwalk)]
                  [string :only (join)])))
 
@@ -11,14 +11,19 @@
 
 (def ^{:dynamic true} *coercions* nil)
 
+(defn generate-to-writer
+  "Attempts to write a json-encoded string for the given Object directly to the given writer."
+  [obj #^Writer writer]
+  (let [generator (.createJsonGenerator factory writer)]
+    (JsonExt/generate generator *coercions* obj)
+    (.flush generator)))
+
 (defn generate-string
   "Returns a JSON-encoding String for the given Clojure object."
   {:tag String}
   [obj]
-  (let [sw        (StringWriter.)
-        generator (.createJsonGenerator factory sw)]
-    (JsonExt/generate generator *coercions* obj)
-    (.flush generator)
+  (let [sw        (StringWriter.)]
+    (generate-to-writer obj sw)
     (.toString sw)))
 
 (defn parse-string

--- a/test/clj_json/core_test.clj
+++ b/test/clj_json/core_test.clj
@@ -1,7 +1,7 @@
 (ns clj-json.core-test
   (:use clojure.test)
   (:require [clj-json.core :as json])
-  (:import (java.io StringReader BufferedReader)
+  (:import (java.io StringReader BufferedReader File FileWriter)
            (java.util HashMap)))
 
 (deftest test-string-round-trip
@@ -18,7 +18,16 @@
   (is (= {"foo" "bar" "1" "bat" "2" "bang" "3" "biz"}
          (json/parse-string
            (json/generate-string
-             {:foo "bar" 1 "bat" (long 2) "bang" (bigint 3) "biz"})))))
+            {:foo "bar" 1 "bat" (long 2) "bang" (bigint 3) "biz"})))))
+
+(deftest test-write-to-tmp
+  (let [f           (File/createTempFile "clj-json-test" "dat")
+        writer      (FileWriter. f)
+        test-object {"a" "cow" "jumped" "over" "the" 88}]
+    (try
+      (json/generate-to-writer test-object writer)
+      (is (= (slurp f) (json/generate-string test-object)))
+      (finally (.close writer)))))
 
 (deftest test-keywords
   (is (= {:foo "bar" :bat 1}


### PR DESCRIPTION
Turns out I was generating some fairly large json strings and I wanted to be able to use other writers besides a StringWriter. This is the smallest change one can possibly make to support that while eliminating unnecessary duplication.
