### PR TITLE
clojure and jackson dependencies

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,8 +1,8 @@
 (defproject clj-json "0.5.1"
   :description "Fast JSON encoding and decoding for Clojure via the Jackson library."
   :url "http://github.com/mmcgrana/clj-json"
-  :source-path "src/clj"
-  :java-source-path "src/jvm"
+  :source-paths ["src/clj"]
+  :java-source-paths ["src/jvm"]
   :javac-fork "true"
-  :dependencies [[org.clojure/clojure "1.3.0"]
-                 [org.codehaus.jackson/jackson-core-asl "1.5.0"]])
+  :dependencies [[org.clojure/clojure "1.4.0"]
+                 [org.codehaus.jackson/jackson-core-asl "1.9.9"]])


### PR DESCRIPTION
Is there any reason why the clj-json jackson dependency is so old? The latest is 1.9.9 now.

``` clojure
:dependencies [[org.clojure/clojure "1.4.0"]
               [org.codehaus.jackson/jackson-core-asl "1.9.9"]])
```
