### PR TITLE
Java 6 compatibility

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -4,5 +4,6 @@
   :source-paths ["src/clj"]
   :java-source-paths ["src/jvm"]
   :javac-fork "true"
+  :javac-options ["-target" "1.6" "-source" "1.6" "-Xlint:-options"]
   :dependencies [[org.clojure/clojure "1.4.0"]
                  [org.codehaus.jackson/jackson-core-asl "1.9.9"]])


### PR DESCRIPTION
Please consider adding Java 6 compatibility to clj-json. 

clj-json doesn't appear to have any Java 7 dependencies or requirements. Oracle still supports Java 6. It's always a good practice to support the current and previous release of Java.

This pull request adds javac flags to compile code for Java 6.
