### PR TITLE
Adding a case for END_ARRAY in JsonExt.

### DIFF
--- a/src/jvm/clj_json/JsonExt.java
+++ b/src/jvm/clj_json/JsonExt.java
@@ -142,6 +142,8 @@ public class JsonExt {
       return Boolean.FALSE;
     case VALUE_NULL:
       return null;
+    case END_ARRAY:
+      return null;
     default:
       throw new Exception("Cannot parse " + jp.getCurrentToken());
     }


### PR DESCRIPTION
I'm using clj-json to parse very large amounts of JSON (>1Gb) so it's very useful to have access to Jackson via clj-json, and laziness is critical, so parsed-seq\* is very useful (and more so if it were public!). However, at the end of a large lazy sequence within a large JSON structure, the END_ARRAY token causes a "Cannot parse" exception to be thrown from JsonExt. This amendment is unlikely to have compatibility issues unless users were handling this exception in their logic. I think the overall benefit of this  change to  those like me who need to parse very large datasets makes it worthwhile - so please consider merging this.
