### PR TITLE
Box small integers as Longs like Clojure, not Integers like .getNumberValue()

### DIFF
--- a/src/jvm/clj_json/JsonExt.java
+++ b/src/jvm/clj_json/JsonExt.java
@@ -3,6 +3,7 @@ package clj_json;
 import org.codehaus.jackson.JsonToken;
 import org.codehaus.jackson.JsonParser;
 import org.codehaus.jackson.JsonGenerator;
+import org.codehaus.jackson.JsonParser.NumberType;
 import java.math.BigInteger;
 import java.util.Iterator;
 import java.util.Map;
@@ -133,7 +134,11 @@ public class JsonExt {
     case VALUE_STRING:
       return jp.getText();
     case VALUE_NUMBER_INT:
-      return jp.getNumberValue();
+      if(jp.getNumberType() == NumberType.BIG_INTEGER) {
+	return jp.getBigIntegerValue();
+      } else {
+	return jp.getLongValue();
+      }
     case VALUE_NUMBER_FLOAT:
       return jp.getDoubleValue();
     case VALUE_TRUE:


### PR DESCRIPTION
This is consistent with the way that Clojure handles small integers, and can avoid unexpected issues downstream when you attempt to, e.g., use these numbers as keys in a HashMap and then look them up with Clojure integer literals.  

I guess it's technically a breaking change, but it didn't break the tests, and Clojure itself has waffled a bit on this sort of behavior without much hubbub (e.g., (int 2) produced an Integer in Clojure 1.0, then a Long in Clojure 1.3, then an Integer again in 1.4, if my memory serves me right).
